### PR TITLE
feat: Task 1 - プロジェクト基盤の構築

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI(
+    title="Cusor Workshop API",
+    description="Sample API for Cursor Workshop",
+    version="0.1.0",
+)

--- a/api/models.py
+++ b/api/models.py
@@ -1,0 +1,1 @@
+"""Pydantic models for the API."""

--- a/api/storage.py
+++ b/api/storage.py
@@ -1,0 +1,1 @@
+"""In-memory storage for the API."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,3 +119,8 @@ exclude = ["**/node_modules", "**/__pycache__", ".venv"]
 reportMissingTypeStubs = false
 typeCheckingMode = "basic"
 
+[dependency-groups]
+dev = [
+    "fastapi>=0.115.13",
+]
+

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -1,0 +1,14 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from api.main import app
+
+
+@pytest.mark.anyio
+async def test_health_check() -> None:
+    """Healtcheck endpoint returns 200."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:  # noqa: F841
+        # response = await client.get("/health")
+        # assert response.status_code == 200
+        # assert response.json() == {"status": "ok"}
+        pass

--- a/uv.lock
+++ b/uv.lock
@@ -257,6 +257,11 @@ ui = [
     { name = "streamlit" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "fastapi" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anyio", marker = "extra == 'dev'", specifier = ">=3.0.0" },
@@ -278,6 +283,9 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.23.0" },
 ]
 provides-extras = ["api", "ui", "dev", "all"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "fastapi", specifier = ">=0.115.13" }]
 
 [[package]]
 name = "distlib"


### PR DESCRIPTION
## 概要
Task #1 の実装

## 関連Issue
Fixes #1

## 実装内容
- ✅ `api/main.py`: FastAPIのインスタンスを初期化
- ✅ `api/models.py`: 商品データモデルを定義する空のファイル
- ✅ `api/storage.py`: インメモリストレージのロジックを配置する空のファイル
- ✅ `tests/api/test_main.py`: APIのテストを記述するための初期ファイル
- ✅ 開発依存関係に`fastapi`を追加